### PR TITLE
feat: fail if source is empty when asserting alarms, events and measurements

### DIFF
--- a/c8y_test_core/assert_alarms.py
+++ b/c8y_test_core/assert_alarms.py
@@ -35,6 +35,9 @@ class Alarms(AssertDevice):
             List[Alarm]: List of matching alarms
         """
         source = kwargs.pop("source", self.context.device_id)
+        assert (
+            source
+        ), "source and the current device context is empty. One of these values must be set!"
         alarms = self.context.client.alarms.get_all(source=source, **kwargs)
 
         matching_alarms = alarms

--- a/c8y_test_core/assert_events.py
+++ b/c8y_test_core/assert_events.py
@@ -40,6 +40,9 @@ class Events(AssertDevice):
             List[Event]: List of matching events
         """
         source = kwargs.pop("source", self.context.device_id)
+        assert (
+            source
+        ), "source and the current device context is empty. One of these values must be set!"
 
         fragment = kwargs.pop("fragment", None)
         if with_attachment:

--- a/c8y_test_core/assert_measurements.py
+++ b/c8y_test_core/assert_measurements.py
@@ -58,6 +58,9 @@ class AssertMeasurements(AssertDevice):
             List[Any]: List of measurements
         """
         source = kwargs.pop("source", self.context.device_id) or None
+        assert (
+            source
+        ), "source and the current device context is empty. One of these values must be set!"
         page_size = kwargs.pop("pageSize", 2000)
 
         measurements = self.context.client.measurements.get_all(


### PR DESCRIPTION
Protect against accidental cases where the user forgot to provide the device context.

By failing hard, it will be more obvious to users what happened rather than potentially passing the count assertion due to detecting measurements, events and alarms from a different source than desired.

In the future this condition could be relaxed by adding an explicit option (noSource=true) but is not currently implemented.