### PR TITLE
fix: use FinalAssertion when device context is missing

### DIFF
--- a/c8y_test_core/assert_alarms.py
+++ b/c8y_test_core/assert_alarms.py
@@ -5,6 +5,7 @@ from typing import List
 from c8y_api.model import Alarm
 
 from c8y_test_core.assert_device import AssertDevice
+from c8y_test_core.errors import FinalAssertionError
 
 
 class AlarmNotFound(AssertionError):
@@ -35,9 +36,10 @@ class Alarms(AssertDevice):
             List[Alarm]: List of matching alarms
         """
         source = kwargs.pop("source", self.context.device_id)
-        assert (
-            source
-        ), "source and the current device context is empty. One of these values must be set!"
+        if not source:
+            FinalAssertionError(
+                "source and the current device context is empty. One of these values must be set!"
+            )
         alarms = self.context.client.alarms.get_all(source=source, **kwargs)
 
         matching_alarms = alarms

--- a/c8y_test_core/assert_events.py
+++ b/c8y_test_core/assert_events.py
@@ -7,6 +7,7 @@ from typing import List, Union
 from c8y_api.model import Event
 
 from c8y_test_core.assert_device import AssertDevice
+from c8y_test_core.errors import FinalAssertionError
 from . import compare
 
 
@@ -40,9 +41,10 @@ class Events(AssertDevice):
             List[Event]: List of matching events
         """
         source = kwargs.pop("source", self.context.device_id)
-        assert (
-            source
-        ), "source and the current device context is empty. One of these values must be set!"
+        if not source:
+            FinalAssertionError(
+                "source and the current device context is empty. One of these values must be set!"
+            )
 
         fragment = kwargs.pop("fragment", None)
         if with_attachment:

--- a/c8y_test_core/assert_measurements.py
+++ b/c8y_test_core/assert_measurements.py
@@ -4,6 +4,7 @@ from typing import Any, List
 from c8y_api.model import ManagedObject, Measurement
 
 from c8y_test_core.assert_device import AssertDevice
+from c8y_test_core.errors import FinalAssertionError
 
 
 class AssertMeasurements(AssertDevice):
@@ -58,9 +59,10 @@ class AssertMeasurements(AssertDevice):
             List[Any]: List of measurements
         """
         source = kwargs.pop("source", self.context.device_id) or None
-        assert (
-            source
-        ), "source and the current device context is empty. One of these values must be set!"
+        if not source:
+            FinalAssertionError(
+                "source and the current device context is empty. One of these values must be set!"
+            )
         page_size = kwargs.pop("pageSize", 2000)
 
         measurements = self.context.client.measurements.get_all(


### PR DESCRIPTION
Use FinalAssertion instead of an Assertion error when the device context is missing so that the assertion will not be retried (as it can never be true in this case).