### PR TITLE
fix: random password generation compatibility

### DIFF
--- a/c8y_test_core/assert_device_registration.py
+++ b/c8y_test_core/assert_device_registration.py
@@ -45,11 +45,17 @@ def random_password(password_len=16) -> str:
         [secrets.choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ") for i in range(0, 2)]
     )
     digits = "".join([secrets.choice("0123456789") for i in range(0, 2)])
-    symbols = "".join([secrets.choice(".$-?@!") for i in range(0, 2)])
+    # use url safe symbols
+    symbols = "".join([secrets.choice("$-_.+!*'(),") for i in range(0, 2)])
     password_requirements = "".join([lowercase, uppercase, digits, symbols])
     password = password_requirements + secrets.token_urlsafe(
         password_len - len(password_requirements) - 2
     )
+    # avoid starting the string with a dash as it can cause cli parsing problems for some
+    # libraries
+    if password.startswith("-"):
+        password = "_" + password[1:]
+
     # randomize order of password
     return "".join(random.sample(password, len(password)))
 

--- a/c8y_test_core/utils.py
+++ b/c8y_test_core/utils.py
@@ -118,7 +118,7 @@ def build_auth_string(auth_value: str) -> str:
     return f"{auth_type} {auth_value}"
 
 
-def _to_csv_str(values, delimiter: str = ","):
+def _to_csv_str(values, delimiter: str = "\t"):
     formatted_values = []
     for v in values:
         if isinstance(v, bool):
@@ -127,10 +127,10 @@ def _to_csv_str(values, delimiter: str = ","):
             formatted_values.append(str(v))
         else:
             formatted_values.append(f'"{v}"')
-    return ",".join(formatted_values)
+    return delimiter.join(formatted_values)
 
 
-def to_csv(items: Tuple[str, List[Any]], delimiter: str = ",") -> str:
+def to_csv(items: Tuple[str, List[Any]], delimiter: str = "\t") -> str:
     """Convert items to csv format
 
     Arguments:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,8 +19,8 @@ class TestCSVConversion(unittest.TestCase):
         )
 
         expected = """
-"col1","col2","col3","col4"
-"hello",true,false,1.234
+"col1"\t"col2"\t"col3"\t"col4"
+"hello"\ttrue\tfalse\t1.234
 """.strip()
         assert output == expected
 
@@ -35,9 +35,9 @@ class TestCSVConversion(unittest.TestCase):
         )
 
         expected = """
-"col1","col2","col3","col4"
-"hello",true,false,1.234
-"again",false,true,10000001
+"col1"\t"col2"\t"col3"\t"col4"
+"hello"\ttrue\tfalse\t1.234
+"again"\tfalse\ttrue\t10000001
 """.strip()
         assert output == expected
 


### PR DESCRIPTION
Fix the compatibility with password generated by:
* using URL safe characters (avoiding having to encode them if they are used within a URL)
* avoid starting the password with "-" due to some bugs in cli parsing libraries which can mistakenly interpret the values as a short option.