### PR TITLE
fix: avoid using single quote in password generation

### DIFF
--- a/c8y_test_core/assert_device_registration.py
+++ b/c8y_test_core/assert_device_registration.py
@@ -46,7 +46,7 @@ def random_password(password_len=16) -> str:
     )
     digits = "".join([secrets.choice("0123456789") for i in range(0, 2)])
     # use url safe symbols
-    symbols = "".join([secrets.choice("$-_.+!*'(),") for i in range(0, 2)])
+    symbols = "".join([secrets.choice("$-_.+!*(),") for i in range(0, 2)])
     password_requirements = "".join([lowercase, uppercase, digits, symbols])
     password = password_requirements + secrets.token_urlsafe(
         password_len - len(password_requirements) - 2


### PR DESCRIPTION
Avoid using a single quote (or double quotes) in the password generation due to problems with shell escaping