### PR TITLE
feat: include the c8y domain when returning the device credentials

### DIFF
--- a/c8y_test_core/assert_device_registration.py
+++ b/c8y_test_core/assert_device_registration.py
@@ -14,6 +14,7 @@ import contextlib
 class DeviceCredentials:
     """Device credentials"""
 
+    url: str
     username: str
     password: str
 
@@ -22,6 +23,7 @@ class DeviceCredentials:
 class DeviceSimpleEnrollCredentials:
     """Device enrollment credentials for the Cumulocity certificate-authority feature"""
 
+    url: str
     external_id: str
     one_time_password: str
 
@@ -114,7 +116,9 @@ class AssertDeviceRegistration(AssertDevice):
         if self.context.client.tenant_id:
             username = f"{self.context.client.tenant_id}/device_{external_id}"
 
-        return DeviceCredentials(username, password)
+        return DeviceCredentials(
+            username=username, password=password, url=self.context.domain()
+        )
 
     def bulk_register_with_ca(
         self,
@@ -163,7 +167,11 @@ class AssertDeviceRegistration(AssertDevice):
             "Failed to register device\n" f"response:\n{resp}"
         )
 
-        return DeviceSimpleEnrollCredentials(external_id, one_time_password)
+        return DeviceSimpleEnrollCredentials(
+            external_id=external_id,
+            one_time_password=one_time_password,
+            url=self.context.domain(),
+        )
 
     def register_with_basic_auth(self, external_id: str, timeout: float = 60, **kwargs):
         """Register a single device using the basic auth

--- a/c8y_test_core/context.py
+++ b/c8y_test_core/context.py
@@ -11,3 +11,10 @@ class AssertContext:
     device_id: str = ""
     client: CumulocityApi = None
     log: logging.Logger = None
+
+    def domain(self) -> str:
+        """Get the Cumulocity domain without the scheme"""
+        url = self.client.base_url.rstrip("/")
+        if "://" in url:
+            return url.split("://")[1]
+        return url


### PR DESCRIPTION
Including the c8y domain within the device credentials class makes it easier to integrate for the user when using 3rd party tools like thin-edge.io