### PR TITLE
fix: fix the return type from the bulk registration with c8y ca

### DIFF
--- a/c8y_test_core/assert_device_registration.py
+++ b/c8y_test_core/assert_device_registration.py
@@ -127,7 +127,7 @@ class AssertDeviceRegistration(AssertDevice):
         name: Optional[str] = None,
         device_type: Optional[str] = "thin-edge.io",
         **kwargs,
-    ) -> DeviceCredentials:
+    ) -> DeviceSimpleEnrollCredentials:
         """Bulk device registration using the Cumulocity
         certificate-authority feature
 


### PR DESCRIPTION
Fix the return type on the `bulk_register_with_ca` function.