### PR TITLE
fix: remove optional type annotation for arguments with typed defaults

### DIFF
--- a/c8y_test_core/assert_binaries.py
+++ b/c8y_test_core/assert_binaries.py
@@ -26,10 +26,10 @@ class Binaries(AssertDevice):
     def new_binary(
         self,
         name: str,
-        binary_type: Optional[str] = "",
+        binary_type: str = "",
         file: Optional[str] = None,
         contents: Optional[Union[str, List]] = None,
-        delete: Optional[bool] = True,
+        delete: bool = True,
         **kwargs,
     ):
         """Upload a binary and provide it to a context. The binary will be automatically

--- a/c8y_test_core/assert_configuration.py
+++ b/c8y_test_core/assert_configuration.py
@@ -88,7 +88,7 @@ class DeviceConfiguration(AssertDevice):
     def assert_supported_types(
         self,
         types: List[str],
-        includes: Optional[bool] = False,
+        includes: bool = False,
         mo: Optional[ManagedObject] = None,
         **kwargs,
     ) -> List[str]:

--- a/c8y_test_core/assert_device_registration.py
+++ b/c8y_test_core/assert_device_registration.py
@@ -72,10 +72,10 @@ class AssertDeviceRegistration(AssertDevice):
     def bulk_register_with_basic_auth(
         self,
         external_id: str,
-        external_type: Optional[str] = "c8y_Serial",
+        external_type: str = "c8y_Serial",
         name: Optional[str] = None,
-        device_type: Optional[str] = "thin-edge.io",
-        auth_type: Optional[str] = "BASIC",
+        device_type: str = "thin-edge.io",
+        auth_type: str = "BASIC",
         **kwargs,
     ) -> DeviceCredentials:
         """Bulk device registration for device that require
@@ -124,9 +124,9 @@ class AssertDeviceRegistration(AssertDevice):
     def bulk_register_with_ca(
         self,
         external_id: str,
-        external_type: Optional[str] = "c8y_Serial",
+        external_type: str = "c8y_Serial",
         name: Optional[str] = None,
-        device_type: Optional[str] = "thin-edge.io",
+        device_type: str = "thin-edge.io",
         **kwargs,
     ) -> DeviceSimpleEnrollCredentials:
         """Bulk device registration using the Cumulocity

--- a/c8y_test_core/assert_events.py
+++ b/c8y_test_core/assert_events.py
@@ -23,7 +23,7 @@ class Events(AssertDevice):
     def assert_count(
         self,
         expected_text: Optional[str] = None,
-        min_matches: Optional[int] = 1,
+        min_matches: int = 1,
         max_matches: Optional[int] = None,
         with_attachment: Optional[bool] = None,
         **kwargs,

--- a/c8y_test_core/assert_inventory.py
+++ b/c8y_test_core/assert_inventory.py
@@ -248,8 +248,8 @@ class AssertInventory(AssertDevice):
     def assert_relationship(
         self,
         child_identity: str,
-        child_identity_type: Optional[str] = "c8y_Serial",
-        child_type: Optional[str] = "childDevices",
+        child_identity_type: str = "c8y_Serial",
+        child_type: str = "childDevices",
         mo: Optional[ManagedObject] = None,
         **kwargs,
     ) -> List[Dict[str, Any]]:
@@ -287,7 +287,7 @@ class AssertInventory(AssertDevice):
     def delete_device_and_user(
         self,
         external_id: str,
-        external_type: Optional[str] = "c8y_Serial",
+        external_type: str = "c8y_Serial",
         **kwargs,
     ) -> None:
         """Assert device user and all child devices. The device user is then deleted afterwards"""
@@ -332,7 +332,7 @@ class AssertInventory(AssertDevice):
         status: Optional[str] = None,
         name: Optional[str] = None,
         query: Optional[str] = None,
-        page_size: Optional[int] = 100,
+        page_size: int = 100,
     ) -> List[ManagedObject]:
         """Get services attached to a specific device
 
@@ -390,7 +390,7 @@ class AssertInventory(AssertDevice):
     def assert_services(
         self,
         inventory_id: Optional[str] = None,
-        min_count: Optional[int] = 1,
+        min_count: int = 1,
         max_count: Optional[int] = None,
         service_type: Optional[str] = None,
         status: Optional[str] = None,

--- a/c8y_test_core/assert_logfile.py
+++ b/c8y_test_core/assert_logfile.py
@@ -14,7 +14,7 @@ class DeviceLogFile(AssertDevice):
     def assert_supported_types(
         self,
         *types: str,
-        include: Optional[bool] = True,
+        include: bool = True,
         mo: Optional[ManagedObject] = None,
         **kwargs,
     ) -> ManagedObject:
@@ -68,8 +68,8 @@ class DeviceLogFile(AssertDevice):
         type: str,
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
-        maximum_lines: Optional[int] = 100,
-        search_text: Optional[str] = "",
+        maximum_lines: int = 100,
+        search_text: str = "",
         **kwargs,
     ) -> AssertOperation:
         """Create a log file request operation c8y_LogfileRequest

--- a/c8y_test_core/assert_operations.py
+++ b/c8y_test_core/assert_operations.py
@@ -14,7 +14,7 @@ class AssertOperations:
 
     def assert_count(
         self,
-        min_count: Optional[int] = 1,
+        min_count: int = 1,
         max_count: Optional[int] = None,
         *,
         fragment: Optional[str] = None,


### PR DESCRIPTION
The `Optional[<type>]` annotation should of only been applied to arguments where the default value is not `None`. This PR removes all of the erroneous type annotations.