### PR TITLE
fix: don't assume c8y_Firmware fragment already exists when comparing info

### DIFF
--- a/c8y_test_core/assert_firmware.py
+++ b/c8y_test_core/assert_firmware.py
@@ -4,6 +4,7 @@ from typing import Optional
 from c8y_api.model import ManagedObject
 
 from c8y_test_core.assert_device import AssertDevice
+from c8y_test_core.assert_inventory import AssertInventory
 from c8y_test_core.assert_operation import AssertOperation
 from c8y_test_core.compare import compare_dataclass
 from c8y_test_core.models import Firmware
@@ -28,9 +29,12 @@ class FirmwareManagement(AssertDevice):
         if mo is None:
             mo = self.context.client.inventory.get(self.context.device_id)
 
-        assert compare_dataclass(mo.to_json()["c8y_Firmware"], expected_firmware), (
+        mo = AssertInventory(self.context).assert_contains_fragments(fragments=["c8y_Firmware"], mo=mo)
+
+        actual_firmware = mo.to_json().get("c8y_Firmware", {})
+        assert compare_dataclass(actual_firmware, expected_firmware), (
             f"Firmware does not match. "
-            f"wanted={expected_firmware}, got={mo.to_json()['c8y_Firmware']}"
+            f"wanted={expected_firmware}, got={actual_firmware}"
         )
         return mo
 
@@ -41,7 +45,10 @@ class FirmwareManagement(AssertDevice):
         if mo is None:
             mo = self.context.client.inventory.get(self.context.device_id)
 
+        mo = AssertInventory(self.context).assert_contains_fragments(fragments=["c8y_Firmware"], mo=mo)
+        actual_firmware = mo.to_json().get("c8y_Firmware", {})
+
         assert not compare_dataclass(
-            mo.to_json()["c8y_Firmware"], expected_firmware
-        ), f"Firmware is installed. wanted=not_installed, got={expected_firmware}"
+            actual_firmware, expected_firmware
+        ), f"Firmware is installed. wanted={expected_firmware}, got={actual_firmware}"
         return mo


### PR DESCRIPTION
Fix a bug when the c8y_Firmware fragment doesn't yet exist on the device which leads the assert to fail early and not be retried.